### PR TITLE
Fixed cmd launch fail when venv path has a space

### DIFF
--- a/pie.py
+++ b/pie.py
@@ -287,7 +287,10 @@ class venv(CmdContext):
     def cmd(self,c):
         """Runs the command `c` in this virtualenv."""
         if WINDOWS:
-            c=r'cmd /c "{}\Scripts\activate.bat && {}"'.format(self.path,c)
+            # cmd.exe /C has real specific behaviour around quotes.
+            # The below double quote syntax is valid because it strips the outside quotes.
+            # The path to activate.bat must be quoted in case it contains spaces
+            c=r'''cmd /c ""{}\Scripts\activate.bat" && {}"'''.format(self.path,c)
         else:
             c=r'bash -c "source {}/bin/activate && {}"'.format(self.path,c)
         return CmdContextManager.cmd(c,self.contextPosition)

--- a/tests/test_context_manager.py
+++ b/tests/test_context_manager.py
@@ -11,7 +11,7 @@ def test_venv_context(pie,pie_tasks_path,pie_mock_cmd):
     second_activate=r'{}\second\Scripts\activate.bat'.format(cwd)
     # TODO: only correct on Windows
     assert len(pie_mock_cmd.cmds)==1
-    assert pie_mock_cmd.cmds[0][0][0]==r'cmd /c "{} && cmd /c "{} && blah""'.format(first_activate,second_activate)
+    assert pie_mock_cmd.cmds[0][0][0]==r'''cmd /c ""{}" && cmd /c ""{}" && blah""'''.format(first_activate,second_activate)
 
 
 @pytest.mark.parametrize('pie_tasks_path',['cd_context'],indirect=['pie_tasks_path'])

--- a/tests/test_pie_requirements.py
+++ b/tests/test_pie_requirements.py
@@ -44,5 +44,6 @@ def test_use_venv(pie,capsys,pie_tasks_path,pie_mock_cmd):
     out,err=capsys.readouterr()
     # TODO: Windows only
     assert len(pie_mock_cmd.cmds)==1
-    assert pie_mock_cmd.cmds[0][0][0].endswith('.venv-pie\\Scripts\\activate.bat && python pie.py test"')
+    assert '.venv-pie\\Scripts\\activate.bat"' in pie_mock_cmd.cmds[0][0][0] or '.venv-pie/Scripts/activate' in pie_mock_cmd.cmds[0][0][0]
+    assert pie_mock_cmd.cmds[0][0][0].endswith('python pie.py test"')
     venv_path.rmdir()


### PR DESCRIPTION
cmd.exe can't find activate.bat if the path contains a space, the path needs to be quoted.

I think this is probably an issue in the bash environment as well, but I don't have a great way to test that at this exact moment.