### PR TITLE
Use subprocess to get stderr and update error msgs

### DIFF
--- a/pie.py
+++ b/pie.py
@@ -228,7 +228,7 @@ class CmdContextManager(object):
     def cmd(cls,c,i=None):
         if i is None: i=len(cls.context)
         if i>0: return cls.context[i-1].cmd(c)
-        process = subprocess.Popen(c, shell=True, stdout=sys.stdout, stderr=sys.stderr, universal_newlines=True)
+        process = subprocess.Popen(c, shell=True, stdout=sys.stdout, stderr=sys.stderr )
         process.communicate()
         if process.returncode!=0:
             raise cls.CmdError(process.returncode,c)


### PR DESCRIPTION
At the moment when a pie.py task fails the stderr output from the command doesn't seem to be provided. 

This PR uses the subprocess.open method to execute the provided command which allows you to control the stdout and stderr behaviour

Also updates the error messages so they can found in the sea of output a bit better

@adamkerz Can you please advise on the right way to run the test suite? I couldn't seem to get all of the tests to pass on the master branch 