### PR TITLE
Change to handle Python3 binary base64 object

### DIFF
--- a/pie_powershell.py
+++ b/pie_powershell.py
@@ -62,7 +62,7 @@ class powershell(CmdContext):
             c=self._buildCmd()
             print('Executing powershell code:\n'+c)
             s=base64.b64encode(c.encode('utf-16le'))
-            c='powershell -EncodedCommand {}'.format(s)
+            c='powershell -EncodedCommand {}'.format(s.decode('utf8'))
             CmdContextManager.cmd(c,self.contextPosition)
         else:
             print('An error occurred, not running powershell commands')


### PR DESCRIPTION
Python 3 prefixes the base64 encoded unicode for the PowerShell command with a "b'", which breaks PowerShell. We decode to utf8 before passing in so PowerShell is happy.

Partial error:

```
Error when executing command "powershell -EncodedCommand b'JABFAHIAcgBvAHIAQQBjAHQAaQBvAG4AUAByAGUAZgBlAHIAZQBuAGMAZQA9ACIAUwB0AG8AcAAiAAoAJABzAD0ATgBlAHcALQBQAFMAUwBlAHMAcwBpAG8AbgAgAC0AQwBvAG0AcAB1AHQAZQByAE4AYQBtAGUAIAAiAHMAcABhAHQAaQBhAGwAYQBwAHAAcwBkAGUAdgAiAAoACgBJAG4AdgBvAGsAZQAtAEMAbwBtAG0AYQBuAGQ......
```

An example posh command that exhibits the issue:

```
Invoke-Command -Session $s -ScriptBlock {
    [Environment]::SetEnvironmentVariable("http_proxy","repterodactyled:80",[System.EnvironmentVariableTarget]::Process)
    [Environment]::SetEnvironmentVariable("https_proxy","repterodactyled.dmz:80",[System.EnvironmentVariableTarget]::Process)
    & "d:\Program Files\ArcGIS\Pro\bin\Python\Scripts\conda.exe" create --copy --no-shortcuts --prefix "G:\repterodactyled\venv" --clone "arcgispro-py3"
}
```